### PR TITLE
Updates links for CPI code reference

### DIFF
--- a/build-cpi.html.md.erb
+++ b/build-cpi.html.md.erb
@@ -34,7 +34,7 @@ Since CPI is just an executable, following takes place for each CPI method call:
 1. CPI executable exits
 1. Callee parses and interprets JSON response ignoring process exit code
 
-As a reference the Director's implementation is in [bosh_cpi's external\_cpi.rb](https://github.com/cloudfoundry/bosh/blob/master/bosh_cpi/lib/cloud/external_cpi.rb) and bosh-init implements it in [cpi\_cmd\_runner.go](https://github.com/cloudfoundry/bosh-init/blob/master/cloud/cpi_cmd_runner.go).
+As a reference the Director's implementation is in [bosh_cpi's external\_cpi.rb](https://github.com/cloudfoundry/bosh/blob/master/src/bosh-director/lib/cloud/external_cpi.rb) and the BOSH CLI implements it in [cpi\_cmd\_runner.go](https://github.com/cloudfoundry/bosh-cli/blob/master/cloud/cpi_cmd_runner.go).
 
 ### <a id='request'></a> Request
 


### PR DESCRIPTION
The director has been refactored to break this link and bosh-init is a bit of a dated reference at this point.

I've pointed at what seem to be the same files at new locations.